### PR TITLE
Make urls relative to apiHost

### DIFF
--- a/ttkd_ui/app/components/checkin/checkin.service.js
+++ b/ttkd_ui/app/components/checkin/checkin.service.js
@@ -1,19 +1,19 @@
 (function() {
-	function CheckinService($http, $filter) {
+	function CheckinService($http, $filter, apiHost) {
 		return {
 			getStudentsFromClass: function(programId) {
-				return $http.get('http://localhost:8000/api/students/?program=' + programId);
+				return $http.get(apiHost + '/api/students/?program=' + programId);
 			},
 			getCurrentCheckinsForClass: function(programId) {
-				return $http.get('http://localhost:8000/api/check-ins/?program=' + programId +
+				return $http.get(apiHost + '/api/check-ins/?program=' + programId +
 					'&date=' + $filter('date')(new Date(), 'yyyy-MM-dd'));
 			},
 			createCheckin: function(data) {
-				return $http.post('http://localhost:8000/api/check-ins/', data);
+				return $http.post(apiHost + '/api/check-ins/', data);
 			}
 		};
 	}
 
 	angular.module('ttkdApp')
-		.factory('CheckinService', ['$http', '$filter', CheckinService]);
+		.factory('CheckinService', ['$http', '$filter', 'apiHost', CheckinService]);
 })();

--- a/ttkd_ui/app/components/classlist/classlist.service.js
+++ b/ttkd_ui/app/components/classlist/classlist.service.js
@@ -2,23 +2,23 @@
 	function ClassListService($http, apiHost) {
 		return {
 			getClassList: function() {
-				return $http.get('http://localhost:8000/api/programs/');
+				return $http.get(apiHost + '/api/programs/');
 			},
 
 			getAllStudents: function() {
-				return $http.get('http://localhost:8000/api/students');
+				return $http.get(apiHost + '/api/students');
 			},
 
 			getStudentsFromClass: function(programId) {
-				return $http.get('http://localhost:8000/api/students/?program=' + programId);
+				return $http.get(apiHost + '/api/students/?program=' + programId);
 			},
 
 			getAllCheckedIn: function() {
-				return $http.get('http://localhost:8000/api/checked-in/persons');
+				return $http.get(apiHost + '/api/checked-in/persons');
 			},
 
 			getClassAttendenceRecords: function(programId) {
-				return $http.get('http://localhost:8000/api/check-ins/?program=' + programId);
+				return $http.get(apiHost + '/api/check-ins/?program=' + programId);
 			}
 		};
 	}


### PR DESCRIPTION
I added this because we still had hard codedURLs. This is how we should do it moving forward. @CCali93 Do you think a constants.js file is better than just reading in a config.json with some values? I have to problem with it. I might make a prod-constants.json file though that has constants we deploy with.

@axv3658 @njc3006 this is how we should get the url for all services
