### PR TITLE
Fix import script registrations

### DIFF
--- a/scripts/import_json.py
+++ b/scripts/import_json.py
@@ -1,4 +1,4 @@
-import json, sys, os, random, datetime
+import json, sys, os, random
 
 students_file = open("students.json").read()
 attendances_file = open("attendances.json").read()


### PR DESCRIPTION
The import script was broken by PR #154, so this will fix it. 

The waivers will never be recoverable from any import data as they are new to the system, so I marked them as IMPORT and gave them a timestamp value. The timestamp will never be seen in the UI without being next to IMPORT, so I feel that this is the best way to resolve this issue. Because we are importing a json file, the auto value on signature_timestamp in registration does not apply, it needs a value, and a value that has a timezone.  

Closes #155 