### PR TITLE
Moved un-needed functionality to an initial setup script

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -12,6 +12,7 @@ gulp buildstage
 cp -R ./dist/* ../dist/static/
 cd ..
 cp scripts/start.bat ./dist/
+cp scripts/initialSetup.bat ./dist/
 cp data.json ./dist/
 cd dist
 python manage.py loaddata data.json

--- a/scripts/initialSetup.bat
+++ b/scripts/initialSetup.bat
@@ -1,0 +1,3 @@
+"%~dp0python-3.5.2-embed-amd64\python.exe" manage.py collectstatic --no-input
+"%~dp0python-3.5.2-embed-amd64\python.exe" manage.py migrate
+"%~dp0python-3.5.2-embed-amd64\python.exe" manage.py loaddata data.json

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -1,4 +1,1 @@
-"%~dp0python-3.5.2-embed-amd64\python.exe" manage.py collectstatic --no-input
-"%~dp0python-3.5.2-embed-amd64\python.exe" manage.py migrate
-"%~dp0python-3.5.2-embed-amd64\python.exe" manage.py loaddata data.json
 start "" "%~dp0python-3.5.2-embed-amd64\python.exe" manage.py runserver 0.0.0.0:80


### PR DESCRIPTION
Every time we start the server we do not want to override data by doing manage.py loaddata. That would only need to be run once, so this PR moves it to a initialSetup.bat. 

closes #308 