### PR TITLE
Format datefield by forcing slashes

### DIFF
--- a/ttkd_ui/app/components/registration/basic_info/basic_info.html
+++ b/ttkd_ui/app/components/registration/basic_info/basic_info.html
@@ -68,6 +68,7 @@
 	<div class="input-group">
 		<input
 			required="required"
+			placeholder="MM/DD/YYYY"
 			type="text"
 			class="form-control"
 			name="dob"
@@ -77,7 +78,6 @@
 			ng-keypress="onDateKeypress($event)"
 			ng-focus="setFocus(3)"
 			ng-required="isFieldRequired('dob')"
-			ng-click="openCalendar($event)"
 			uib-datepicker-popup="MM/dd/yyyy"
 			ng-model="registrationInfo.person.dob.value"
 			is-open="registrationInfo.person.dob.open"

--- a/ttkd_ui/app/components/registration/registration.controller.js
+++ b/ttkd_ui/app/components/registration/registration.controller.js
@@ -103,6 +103,10 @@
 				else if ($event.target.value.length < 10) {
 					$event.target.value += $event.key
 				}
+
+				if($event.target.value.length === 10) {
+					$scope.registrationInfo.person.dob.value = moment($event.target.value, "MM/DD/YYYY").toDate();
+				}
 			}
 			$event.preventDefault();
 		};
@@ -240,11 +244,13 @@
 				var today = moment();
 				var birthday = moment($scope.registrationInfo.person.dob.value);
 
-				var ageInYears = today.diff(birthday, 'years');
+				if(birthday !== undefined) {
+					var ageInYears = today.diff(birthday, 'years');
 
-				return ageInYears <= 1;
+					return ageInYears <= 1;
+				}
 			}
-			return true;
+			return false;
 		};
 
 		$scope.formattedDob = function() {


### PR DESCRIPTION
Closes #347. 

To test this go to the registration page. Verify that the datepicker still works. Verify that you can add a correct date, then mess around and see if you can get it to break. 

I put time into making sure that you could backspace and that copy/pasted invalid strings were shown as incorrect dates. I added a regex pattern to the field to point out any incorrect date formats as a fallback too (this is useful for catching copy/paste mistakes)