### PR TITLE
Fix plus-minus button bug by changing variable names

### DIFF
--- a/ttkd_ui/app/components/registration/basic_info/basic_info.html
+++ b/ttkd_ui/app/components/registration/basic_info/basic_info.html
@@ -245,7 +245,7 @@
 					type="button"
 					class="btn btn-danger"
 					ng-click="removeEmail($index)"
-					ng-show="registrationInfo.emails.length > 1">
+					ng-show="registrationInfo.person.emails.length > 1">
 					<i class="glyphicon glyphicon-minus"></i>
 				</button>
 			</span>

--- a/ttkd_ui/app/components/registration/registration.controller.js
+++ b/ttkd_ui/app/components/registration/registration.controller.js
@@ -349,7 +349,7 @@
 		};
 
 		$scope.removeEmail = function(index) {
-			$scope.registrationInfo.emails.splice(index, 1);
+			$scope.registrationInfo.person.emails.splice(index, 1);
 			$scope.numElements--;
 		};
 


### PR DESCRIPTION
Closes #375.

To Reproduce: On develop branch go to registration screen, and click the plus button for emails. You should see something like this show up:
<img width="936" alt="screen shot 2017-04-02 at 9 33 04 pm" src="https://cloud.githubusercontent.com/assets/3743516/24593047/409921d0-17ed-11e7-999c-ee8dbea33138.png">

To test: Check out this branch and do that same workflow, you should see the red minus buttons next to email fields now.
