### PR TITLE
Added in opacity for student pictures only when they are checked in

### DIFF
--- a/ttkd_ui/app/components/checkin/checkin.html
+++ b/ttkd_ui/app/components/checkin/checkin.html
@@ -76,9 +76,11 @@
             <div>
                 <pic class="wrapper pic">
                     <img ng-if="person.picture_url" class="img-responsive {{studentBeltClass}} pull-left"
-                         ng-src="{{apiHost}}/{{person.picture_url}}" ng-style="person.beltStyle"/>
+                         ng-src="{{apiHost}}/{{person.picture_url}}" ng-style="person.beltStyle"
+                         ng-class="{'checked checked-in-faded': person.checkedIn, 'unchecked' : !person.checkedIn}"/>
                     <img ng-if="!person.picture_url" class="img-responsive {{studentBeltClass}} pull-left"
-                         ng-src="./img/components/students/placeholder.png" ng-style="person.beltStyle"/>
+                         ng-src="./img/components/students/placeholder.png" ng-style="person.beltStyle"
+                         ng-class="{'checked checked-in-faded': person.checkedIn, 'unchecked' : !person.checkedIn}"/>
                     <span ng-if="person.checkedIn" class="glyphicon glyphicon-ok-circle"></span>
                 </pic>
     			<svg class="stripes pull-right">

--- a/ttkd_ui/app/components/checkin/checkin.scss
+++ b/ttkd_ui/app/components/checkin/checkin.scss
@@ -5,6 +5,11 @@
 	    cursor: default;
 	}
 
+    .checked-in-faded{
+        opacity: 0.4;
+        filter: alpha(opacity=40); /* msie */
+    }
+
 	.datepicker {
 		min-width: 210px;
 	}


### PR DESCRIPTION
closes #393 

The picture and belt should be faded, while the checkbox, stripes, and name should not be.

I think the checkbox needs a higher contrast color to stand out. Right now it blends in with the faded picture too well.