### PR TITLE
Fix function call to only pull actives. Closes #409

### DIFF
--- a/ttkd_ui/app/components/students/detail/edit/student.edit.controller.js
+++ b/ttkd_ui/app/components/students/detail/edit/student.edit.controller.js
@@ -15,7 +15,7 @@
         var programsTouched = false;
         var allPrograms = [];
 
-        ProgramsService.getPrograms().then(
+        ProgramsService.getActivePrograms().then(
             function (response) {
                 allPrograms = response.data;
                 initPrograms();


### PR DESCRIPTION
If a student is currently in an inactive class that class will still show in the dropdown after it is deleted. Though wont be there on next open after saving the removal from the class.