### PR TITLE
Move the reload to right before the backnav.

### DIFF
--- a/ttkd_ui/app/components/programs/edit-program.controller.js
+++ b/ttkd_ui/app/components/programs/edit-program.controller.js
@@ -113,9 +113,7 @@
                         $scope.alerts.success = true;
                         $scope.alerts.error = false;
                         $window.scrollTo(0, 0);
-                        if(programCookie.id == $scope.program.id) {
-                            location.reload();
-                        }
+                        location.reload();
                         $scope.backNavigate();
                     }
                 });


### PR DESCRIPTION
This fixes the issues when making edits to the current class. Changing name and adding/removing students/instructors