### PR TITLE
Documentation Fix

### DIFF
--- a/ttkd_api/ttkd_api/views/belt_views.py
+++ b/ttkd_api/ttkd_api/views/belt_views.py
@@ -6,11 +6,12 @@ from ..permissions import custom_permissions
 
 
 class BeltViewSet(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     """
-    GET: Returns all Belt Objects To The Route, Or An Instance If Given A PK. Filters: belt
+    GET: Returns all Belt Objects To The Route, Or An Instance If Given A PK.
+    Filters: active
     POST: Create A Belt
     """
+    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     queryset = Belt.objects.all()
     serializer_class = BeltSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/ttkd_api/ttkd_api/views/email_views.py
+++ b/ttkd_api/ttkd_api/views/email_views.py
@@ -6,11 +6,12 @@ from ..permissions import custom_permissions
 
 
 class EmailViewSet(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)
     """
-    GET: Returns all Email Objects To The Route, Or An Instance If Given A PK. Filters: person
+    GET: Returns all Email Objects To The Route, Or An Instance If Given A PK.
+    Filters: person
     POST: Create A Email
     """
+    permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)
     queryset = Email.objects.all()
     serializer_class = EmailSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/ttkd_api/ttkd_api/views/instructor_views.py
+++ b/ttkd_api/ttkd_api/views/instructor_views.py
@@ -10,7 +10,7 @@ from ..permissions import custom_permissions
 
 class MinimalInstructorViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    Returns all Instructors (with limited persons) objects to the Route.
+    GET: Returns all Instructors (with limited persons) objects to the Route.
     Filters: program
     """
     permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)
@@ -22,7 +22,8 @@ class MinimalInstructorViewSet(viewsets.ReadOnlyModelViewSet):
 
 class InstructorViewSet(viewsets.ModelViewSet):
     """
-    Returns all Instructors objects to the Route.
+    GET: Returns all Instructors objects to the Route.
+    POST: Create a new instructor
     Filters: program
     """
     permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)
@@ -34,7 +35,8 @@ class InstructorViewSet(viewsets.ModelViewSet):
 
 class InstructorAttendanceViewSet(viewsets.ModelViewSet):
     """
-    Returns all Instructor attendance record objects to the Route.
+    GET: Returns all Instructor attendance record objects to the Route.
+    POST: Create a new instructor attendance record, date not required
     Filters: program
     """
     permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)
@@ -44,9 +46,9 @@ class InstructorAttendanceViewSet(viewsets.ModelViewSet):
     filter_fields = ('program', 'person', 'date')
 
 
-class DetailedInstructorAttendanceViewSet(viewsets.ModelViewSet):
+class DetailedInstructorAttendanceViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    Returns all Instructors objects to the Route.
+    GET: Returns all instructor attendance records with a full instructor object
     Filters: program
     """
     permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)

--- a/ttkd_api/ttkd_api/views/people_views.py
+++ b/ttkd_api/ttkd_api/views/people_views.py
@@ -6,11 +6,11 @@ from ..permissions import custom_permissions
 
 
 class PeopleViewSet(viewsets.ReadOnlyModelViewSet):
-    permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)
     """
     Returns all People (limited persons) objects to the Route.
     Filters: first_name, last_name, belt, active
     """
+    permission_classes = (custom_permissions.IsAuthenticatedOrOptions,)
     queryset = Person.objects.all()
     serializer_class = PeopleSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/ttkd_api/ttkd_api/views/person_belt_views.py
+++ b/ttkd_api/ttkd_api/views/person_belt_views.py
@@ -4,7 +4,7 @@ from ..serializers.person_belt_serializer import PersonBeltSerializer, DetailedP
 from ..models.person_belt import PersonBelt
 from rest_framework import permissions
 
-class DetailedPersonBeltViewSet(viewsets.ModelViewSet):
+class DetailedPersonBeltViewSet(viewsets.ReadOnlyModelViewSet):
     """
     GET: Returns all PersonBelt Objects To The Route, with detailed information on belt Or An Instance If Given A PK.
     Filters: person, belt
@@ -16,12 +16,12 @@ class DetailedPersonBeltViewSet(viewsets.ModelViewSet):
     filter_fields = ('person', 'belt')
 
 class PersonBeltViewSet(viewsets.ModelViewSet):
-    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     """
     GET: Returns all PersonBelt Objects To The Route, Or An Instance If Given A PK.
     Filters: person, belt
     POST: Create a person Belt record
     """
+    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = PersonBelt.objects.all()
     serializer_class = PersonBeltSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/ttkd_api/ttkd_api/views/person_views.py
+++ b/ttkd_api/ttkd_api/views/person_views.py
@@ -28,7 +28,6 @@ class PersonFilter(drf_filters.FilterSet):
         }
 
 class PersonViewSet(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.IsAdminOrAuthReadOnly,)
     """
     Returns all Person objects to the Route.
     GET: Returns all PersonStripe Objects To The Route, Or An Instance If Given A PK.
@@ -37,6 +36,7 @@ class PersonViewSet(viewsets.ModelViewSet):
     POST: NOT SUPPORTED
     Filters: first_name, last_name, active
     """
+    permission_classes = (custom_permissions.IsAdminOrAuthReadOnly,)
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -112,10 +112,10 @@ class PersonNotesViewSet(viewsets.ModelViewSet):
     queryset = Person.objects.all()
     serializer_class = NotesPersonSerializer
 
-class PersonMinimalViewSet(viewsets.ModelViewSet):
+class PersonMinimalViewSet(viewsets.ReadOnlyModelViewSet):
     """
     Returns all Person objects to the Route with id, first, and last name.
-    GET: Returns all person objexts, Or An Instance If Given A PK.
+    GET: Returns all person objects, Or An Instance If Given A PK.
     PUT: NOT SUPPORTED
     POST: NOT SUPPORTED
     """

--- a/ttkd_api/ttkd_api/views/program_views.py
+++ b/ttkd_api/ttkd_api/views/program_views.py
@@ -9,11 +9,11 @@ from ..permissions import custom_permissions
 
 
 class ProgramViewSet(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     """
     GET: Returns all Program Objects To The Route, Or An Instance If Given A PK
     POST: Create A Program
     """
+    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     queryset = Program.objects.all().order_by(Lower('name'))
     serializer_class = ProgramSerializer
     filter_backends = (filters.DjangoFilterBackend,)
@@ -21,11 +21,11 @@ class ProgramViewSet(viewsets.ModelViewSet):
 
 
 class StudentList(viewsets.ReadOnlyModelViewSet):
-    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     """
     Get The Student List for a given program, you must specify ?program=<id> to get a student
     list for a given program. Filters: program
     """
+    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = Registration.objects.all()
     serializer_class = RegistrationSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/ttkd_api/ttkd_api/views/stripe_views.py
+++ b/ttkd_api/ttkd_api/views/stripe_views.py
@@ -6,11 +6,12 @@ from ..permissions import custom_permissions
 
 
 class StripeViewSet(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     """
-    GET: Returns all Stripe Objects To The Route, Or An Instance If Given A PK. Filters: active
+    GET: Returns all Stripe Objects To The Route, Or An Instance If Given A PK.
+    Filters: active
     POST: Create A Stripe
     """
+    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     queryset = Stripe.objects.all()
     serializer_class = StripeSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/ttkd_api/ttkd_api/views/user_views.py
+++ b/ttkd_api/ttkd_api/views/user_views.py
@@ -7,12 +7,12 @@ from ..permissions import custom_permissions
 
 
 class UserViewSet(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     """
     Returns all User objects to the Route.
     GET: Returns all User Objects To The Route, Or An Instance If Given A PK.
     PUT: Update a specific User.
     """
+    permission_classes = (custom_permissions.IsAdminOrReadOnly,)
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
@@ -26,12 +26,12 @@ class UserViewSet(viewsets.ModelViewSet):
 
 
 class ChangePasswordView(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.CurrentUserPassword,)
     """
     Returns all User objects to the Route.
     GET: Returns all User Objects To The Route, Or An Instance If Given A PK.
     PUT: Update a specific User.
     """
+    permission_classes = (custom_permissions.CurrentUserPassword,)
     queryset = User.objects.all()
     serializer_class = UserPasswordSerializer
 
@@ -45,12 +45,12 @@ class ChangePasswordView(viewsets.ModelViewSet):
 
 
 class UserInfoView(viewsets.ModelViewSet):
-    permission_classes = (custom_permissions.IsAdminPutOnly,)
     """
     Returns all User objects to the Route.
     GET: Returns all User Objects To The Route, Or An Instance If Given A PK.
     PUT: Update a specific User.
     """
+    permission_classes = (custom_permissions.IsAdminPutOnly,)
     queryset = User.objects.all()
     serializer_class = UserInfoSerializer
 


### PR DESCRIPTION
Fixing doc string violation so that the descriptions show in the browsable api. Also fixed and endpoint that needs to be read only

Lines of code above the doc strings for many views. This is terrible python, and it broke the descriptions showing up in the browsable api. 

This should not change the system at all, but lets not merge it until after the semester is over. That way future users can at least have this. 